### PR TITLE
new option to specify cluster name

### DIFF
--- a/run_microservices.py
+++ b/run_microservices.py
@@ -121,7 +121,6 @@ def start_kubernetes(platform, multizonal, application, cluster_name):
             cmd += "us-central1-c us-central1-a "
         else:
             cmd += "--zone=us-central1-a "
-        print(cmd)
         result = util.exec_process(cmd)
         cmd = f"gcloud services enable container.googleapis.com --project {PROJECT_ID} && "
         cmd += f"gcloud services enable monitoring.googleapis.com cloudtrace.googleapis.com "


### PR DESCRIPTION
Because we are running different clusters to test different things, it is useful to be able to specify the cluster name at startup/teardown.  This adds an option for that in the main script run_microservices.py.